### PR TITLE
fixed the FI locale

### DIFF
--- a/locale/fi.yml
+++ b/locale/fi.yml
@@ -1,5 +1,5 @@
 ---
-en:
+fi:
   headings:
     # "Academic Achievements"
     acad_achievements: "Akateemiset saavutukset"


### PR DESCRIPTION
Before this fix, using the `EN` locale used the `FI` one in practice.